### PR TITLE
Fix: Require ext/intl for dev environments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">=5.4"
     },
     "require-dev": {
+        "ext-intl": "*",
         "umpirsky/list-generator": "^1.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ffab212fc76a8956a8207de1ecc5c2a0",
-    "content-hash": "0625bee412eb2ef9993c7dc1533a5738",
+    "hash": "ef0661394edd07043fe1dd0ca26cc970",
+    "content-hash": "93b4fb5eacc7e9c2964a30da4e65eb53",
     "packages": [],
     "packages-dev": [
         {
@@ -962,5 +962,7 @@
     "platform": {
         "php": ">=5.4"
     },
-    "platform-dev": []
+    "platform-dev": {
+        "ext-intl": "*"
+    }
 }


### PR DESCRIPTION
This PR
- [x] requires `ext/intl` for development environments, as otherwise it's impossible to rebuild the files

:information_desk_person: This is what happens if `ext/intl` isn't installed:

```
$ bin/build
PHP Fatal error:  Call to undefined function idn_to_utf8() in /Users/am/Sites/umpirsky/tld-list/bin/build on line 25

Fatal error: Call to undefined function idn_to_utf8() in /Users/am/Sites/umpirsky/tld-list/bin/build on line 25
```
